### PR TITLE
bumb weaviate version

### DIFF
--- a/HybridSearch_example/Makefile
+++ b/HybridSearch_example/Makefile
@@ -148,7 +148,7 @@ db:
 		-e ASYNC_INDEXING="true" \
 		-e USE_BLOCKMAX_WAND="true" \
 		-e USE_INVERTED_SEARCHABLE="true" \
-		semitechnologies/weaviate:1.31.0
+		semitechnologies/weaviate:1.32.0
 
 #shutdown weaviate
 db_down:

--- a/HybridSearch_example/docker-compose.yml
+++ b/HybridSearch_example/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - '8080'
       - --scheme
       - http
-    image: semitechnologies/weaviate:1.31.0 #https://weaviate.io/developers/weaviate/release-notes#weaviate-core-and-client-releases
+    image: semitechnologies/weaviate:1.32.0 #https://weaviate.io/developers/weaviate/release-notes#weaviate-core-and-client-releases
     ports:
       - 8080:8080
       - 50051:50051


### PR DESCRIPTION
This pull request updates the Weaviate database container image version used in both the `Makefile` and `docker-compose.yml` files to ensure the project runs with the latest features and fixes.

Dependency version update:

* Updated the Weaviate Docker image from `1.31.0` to `1.32.0` in `HybridSearch_example/Makefile` for database startup.
* Updated the Weaviate Docker image from `1.31.0` to `1.32.0` in `HybridSearch_example/docker-compose.yml` for the main service definition.